### PR TITLE
 Handle path with spaces and double-quotes on Windows

### DIFF
--- a/create_project.bat
+++ b/create_project.bat
@@ -5,8 +5,8 @@ REM ---------------------------------------------------------------------------
 REM Validate args
 REM ---------------------------------------------------------------------------
 
-if "%1"=="" goto OnShowCommandLineHelp
-if "%2"=="" goto OnShowCommandLineHelp
+if [%1]==[] goto OnShowCommandLineHelp
+if [%2]==[] goto OnShowCommandLineHelp
 
 REM ---------------------------------------------------------------------------
 REM Create Project
@@ -88,7 +88,7 @@ call :MakeReplace "%vbsfile%"
 for /f "tokens=*" %%a in ('dir "%srcDir%" /s /b /a-d /on') do (
   for /f "usebackq" %%b in (`Findstr /mic:"%~1" "%%a"`) do (
     echo(&Echo Replacing "%~1" with "%~2" in file %%~nxa
-    <%%a cscript //nologo %vbsfile% "%~1" "%~2" > "%tmpfile%"
+    <%%a cscript //nologo "%vbsfile%" "%~1" "%~2" > "%tmpfile%"
     if exist "%tmpfile%" move /Y "%tmpfile%" "%%~dpnxa">nul
   )
 )


### PR DESCRIPTION
Hi,

I think solve problem with creating plugin template when pass path with spaces and double-quotes on Windows like 

`create_project.bat "F:\STUDIA\My projects\Plugin_Name" Plugin_Name `

Tested on Windows 7 64-bit.

ldurniat